### PR TITLE
chore: add .clinerules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *.log
 .env*
 !.env.example
+.clinerules


### PR DESCRIPTION
Add .clinerules to .gitignore so each developer can add their own rules. We may consider adding back suggested rules later.

Closes #3